### PR TITLE
Allow specifying maxPayload for WebSocket client

### DIFF
--- a/lib/websocket.ts
+++ b/lib/websocket.ts
@@ -36,6 +36,17 @@ enum ConnectionStatus {
   Connected,
 }
 
+/**
+ * Override defaults for ws in node
+ *
+ * @todo make sure this does not break in browser
+ */
+class BetterWebSocket extends WebSocket {
+  constructor(url: string | URL, protocols = [], { maxPayload = 0, ...rest }) {
+    super(url, protocols, { maxPayload, ...rest });
+  }
+}
+
 export class WebSocketClient extends EventEmitter implements Connection {
   private _ws: Promise<ReconnectingWebSocket>;
   private _domain: string;
@@ -56,7 +67,7 @@ export class WebSocketClient extends EventEmitter implements Connection {
     this._ws = new Promise<ReconnectingWebSocket>((resolve) => {
       // create websocket connection
       const ws = new ReconnectingWebSocket("wss://" + this._domain, [], {
-        WebSocket,
+        WebSocket: BetterWebSocket,
       });
 
       // register handlers

--- a/lib/websocket.ts
+++ b/lib/websocket.ts
@@ -42,7 +42,11 @@ enum ConnectionStatus {
  * @todo make sure this does not break in browser
  */
 class BetterWebSocket extends WebSocket {
-  constructor(url: string | URL, protocols = [], { maxPayload = 0, ...rest }) {
+  constructor(
+    url: string | URL,
+    protocols = [],
+    { maxPayload = 0, ...rest } = {}
+  ) {
     super(url, protocols, { maxPayload, ...rest });
   }
 }


### PR DESCRIPTION
The default is 100MB with `ws`. This is maybe a reasonable default, but by default the client and the server both check. I feel like most of the time you are OK with what the server wants.

I have disabled the client-side check by default, added a way for the user of `client` to specify the `maxPayload` they want. I am open to thoughts on a different default, the main thing is there should be a way to change this setting when using `client`.