### PR TITLE
Add HTTP connection type

### DIFF
--- a/lib/http.ts
+++ b/lib/http.ts
@@ -1,0 +1,154 @@
+import fetch from 'cross-fetch';
+import { EventEmitter } from "events";
+import ksuid from "ksuid";
+import PQueue from "p-queue";
+import debug from "debug";
+import oerror from '@overleaf/o-error';
+
+const trace = debug("@oada/client:http:trace");
+const warn = debug("@oada/client:http:warn");
+//const error = debug("@oada/client:http:error");
+
+import { ConnectionRequest, ConnectionResponse, ConnectionChange, Connection } from './client';
+
+import { assert as assertOADASocketRequest } from "@oada/types/oada/websockets/request";
+import { delay } from './utils';
+
+enum ConnectionStatus {
+  Disconnected,
+  Connecting,
+  Connected,
+}
+
+export class HttpClient extends EventEmitter implements Connection {
+  private _domain: string;
+  private _token: string;
+  private _status: ConnectionStatus;
+  private _q: PQueue;
+  private initialConnection: Promise<void>; // await on the initial HEAD
+
+  /**
+   * Constructor
+   * @param domain Domain. E.g., www.example.com
+   * @param concurrency Number of allowed in-flight requests. Default 10.
+   */
+  constructor(domain: string, token: string, concurrency = 10) {
+    super();
+    this._domain = domain.match(/^http/) ? domain : `https://${domain}`; // ensure leading https://
+    this._domain = this._domain.replace(/\/$/, ''); // ensure no trailing slash
+    this._token = token;
+    this._status = ConnectionStatus.Connecting;
+    // "Open" the http connection: just make sure a HEAD succeeds
+    trace(`Opening the HTTP connection to HEAD ${this._domain}/bookmarks w/ headers authorization: Bearer ${this._token}`);
+    this.initialConnection = fetch(`${this._domain}/bookmarks`, {
+      method: 'HEAD',
+      headers: { 'authorization': `Bearer ${this._token}` }
+    }).then(result => {
+      trace('Initial HEAD returned status: ', result.status);
+      if (result.status < 400) {
+        trace('Initial HEAD succeeded, emitting "open"');
+        this._status = ConnectionStatus.Connected;
+        this.emit("open");
+      } else {
+        trace('Initial HEAD failed, emitting "close"');
+        this._status = ConnectionStatus.Disconnected;
+        this.emit('close');
+      }
+    });
+
+    this._q = new PQueue({ concurrency });
+    this._q.on("active", () => {
+      trace(`HTTP Queue. Size: ${this._q.size} pending: ${this._q.pending}`);
+    });
+  }
+
+  /** Disconnect the WebSocket connection */
+  public async disconnect(): Promise<void> {
+    this._status = ConnectionStatus.Disconnected;
+    this.emit('close');
+  }
+
+  /** Return true if connected, otherwise false */
+  public isConnected(): boolean {
+    return this._status == ConnectionStatus.Connected;
+  }
+
+  /** Wait for the connection to open */
+  public async awaitConnection(): Promise<void> {
+    // Wait for the initial HEAD request to return
+    await this.initialConnection;
+  }
+
+  public request(
+    req: ConnectionRequest,
+    callback?: (response: Readonly<ConnectionChange>) => void,
+    timeout?: number
+  ): Promise<ConnectionResponse> {
+    trace('Starting http request: ', req);
+    if (req.method === 'watch' || req.method === 'unwatch') {
+      throw new Error('HTTP (i.e. non-WebSocket) Client cannot do watches');
+    }
+    if (callback) {
+      throw new Error('HTTP (i.e. non-WebSocket) Client cannot handle a watch callback');
+    }
+    if (!req.requestId) req.requestId = ksuid.randomSync().string;
+    trace('Adding http request w/ id ',req.requestId, ' to the queue');
+    return this._q.add(() => this.doRequest(req, timeout));
+  }
+
+  /** send a request to server */
+  private async doRequest(
+    req: ConnectionRequest,
+    timeout?: number
+  ): Promise<ConnectionResponse> {
+    // Send object to the server.
+    trace('Pulled request ', req.requestId, ' from queue, starting on it');
+    assertOADASocketRequest(req);
+    trace(`Req looks like a socket request, awaiting race between timeout and fetch to ${this._domain}${req.path}`);
+
+    let timedout = false;
+    if (timeout) {
+      setTimeout(() => timedout = true, timeout);
+    }
+    const result = await fetch(`${this._domain}${req.path}`, {
+      method: req.method.toUpperCase(),
+      body: JSON.stringify(req.data),
+      headers: req.headers, // We are not explicitly sending token in each request because parent library sends it
+    }).then(res => {
+      if (timedout) throw new Error('Request timeout');
+      return res;
+    });
+    trace(`Fetch did not throw, checking status of ${result.status}`);
+
+    // This is the same test as in ./websocket.ts
+    if (result.status < 200 || result.status >= 300) {
+      trace(`result.status (${result.status}) is not 2xx, throwing`);
+      throw result;
+    }
+    trace(`result.status ok, pulling headers`);
+    // have to construct the headers ourselves:
+    const headers: Record<string,string> = {};
+    result.headers.forEach((value, key) => headers[key] = value);
+    const length = +(result.headers.get('content-length') || 0);
+    let data: any = null;
+    if (req.method.toUpperCase() !== 'HEAD') { 
+      const isJSON = (result.headers.get('content-type') || '').match(/json/);
+      if (!isJSON) {
+        data = await result.arrayBuffer();
+      } else {
+        // this json() function is really finicky, have to do all these tests prior to get it to work
+        data = await result.json();
+      }
+    }
+    trace(`length = ${length}, result.headers = `, headers);
+    return {
+      requestId: req.requestId,
+      status: result.status,
+      statusText: result.statusText,
+      headers,
+      data
+    };
+
+  }
+}
+

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -3,7 +3,6 @@ import { EventEmitter } from "events";
 import ksuid from "ksuid";
 import PQueue from "p-queue";
 import debug from "debug";
-import oerror from '@overleaf/o-error';
 
 const trace = debug("@oada/client:http:trace");
 const warn = debug("@oada/client:http:warn");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oada/client",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A lightweight client tool to interact with an OADA-compliant server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oada/client",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A lightweight client tool to interact with an OADA-compliant server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -18,7 +18,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@oada/types": "^1.0.6",
-    "@overleaf/o-error": "^3.2.0",
     "cross-fetch": "^3.0.6",
     "debug": "^4.1.1",
     "isomorphic-ws": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@oada/types": "^1.0.6",
+    "@overleaf/o-error": "^3.2.0",
+    "cross-fetch": "^3.0.6",
     "debug": "^4.1.1",
     "isomorphic-ws": "^4.0.1",
     "ksuid": "^1.2.0",

--- a/test/cleanup.ts
+++ b/test/cleanup.ts
@@ -1,0 +1,24 @@
+import * as config from "./config";
+import * as utils from "./utils";
+import * as readline from 'readline'; // node.js native readline
+
+(async function() {
+
+  const bookmarks = await utils.getAxios(`/bookmarks`).then(res => res.data);
+  const testkeys = Object.keys(bookmarks).filter(k => k.match(/test-/));
+
+  const readline = require('readline');
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  rl.question('About to delete keys '+JSON.stringify(testkeys)+' from OADA.  Proceed (y/N)? ', async (answer) => {
+    rl.close();
+    if (answer !== 'y') {
+      console.log('Not deleting keys because you didn\'t type "y"');
+      return;
+    }
+    console.log('Deleting keys...');
+    await Promise.all(testkeys.map(k => utils.deleteLinkAxios(`/bookmarks/${k}`)));
+    console.log('Keys deleted.');
+  });
+
+})();

--- a/test/get.test.ts
+++ b/test/get.test.ts
@@ -1,14 +1,15 @@
-import chai from "chai";
-const chaiAsPromised = require("chai-as-promised");
-chai.use(chaiAsPromised);
-const expect = chai.expect;
+import { expect, use } from "chai";
 import "mocha";
-import ksuid from "ksuid";
 import * as oada from "../lib/index";
 import * as config from "./config";
 import * as utils from "./utils";
+const ksuid = require("ksuid");
+use(require("chai-as-promised"));
 
-describe("GET test", function () {
+['ws', 'http'].forEach(connection => {
+if (connection !== 'ws' && connection !== 'http') return;
+
+describe(connection+" GET test", function () {
   // Client instance
   let client: oada.OADAClient;
 
@@ -25,6 +26,7 @@ describe("GET test", function () {
     client = await oada.connect({
       domain: config.domain,
       token: config.token,
+      connection,
     });
   });
 
@@ -104,7 +106,7 @@ describe("GET test", function () {
         path: "/bookmarks/test/testTwo",
         tree: testTree,
       })
-    ).to.be.rejected;
+    ).to.eventually.be.rejected;
   });
 
   it("Should allow you to get resources based on a tree", async function () {
@@ -130,7 +132,6 @@ describe("GET test", function () {
       path: basePath,
       tree: testTree,
     });
-
     // Check
     expect(response.status).to.equal(200);
     expect(response.data).to.include.keys(["_id", "_rev", "_type", "_meta"]);
@@ -145,4 +146,6 @@ describe("GET test", function () {
       "aaa.bbb.index-one.ccc.index-two.bob.index-three.2018"
     );
   });
+});
+
 });

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1,0 +1,123 @@
+import { use, expect } from "chai";
+import "mocha";
+import * as oada from "../lib/index";
+import * as config from "./config";
+use(require('chai-as-promised'));
+
+const generateRandomStr = () => {
+  return Math.random().toString(36).substring(7);
+};
+
+describe("HTTP Client test", function () {
+  it("HTTP Connect/Disconnect", async () => {
+    const client = await oada.connect({
+      domain: config.domain,
+      token: config.token,
+      connection: 'http',
+    });
+    await client.disconnect();
+  });
+
+  it("HTTP Single GET", async () => {
+    const client = await oada.connect({
+      domain: config.domain,
+      token: config.token,
+      connection: 'http',
+    });
+    const response = await client.get({ path: "/bookmarks" });
+    expect(response.status).to.equal(200);
+    expect(response.data).to.have.nested.property(`_type`);
+    //expect(response.data?._type).to.equal("application/vnd.oada.bookmarks.1+json");
+    await client.disconnect();
+  });
+
+  it("HTTP watch should throw", async () => {
+    const client = await oada.connect({
+      domain: config.domain,
+      token: config.token,
+      connection: 'http',
+    });
+    await expect(client.watch({
+      path: "/bookmarks",
+      watchCallback: console.log,
+    })).to.eventually.be.rejected;
+  });
+
+  it("HTTP PUT->GET->DELETE", async () => {
+    const client = await oada.connect({
+      domain: config.domain,
+      token: config.token,
+      connection: 'http',
+    });
+    const response = await client.put({
+      path: "/bookmarks",
+      data: { test10: "aaa" },
+    }).then(() => client.get({path:`/bookmarks/test10`}))
+    .then(async res => {
+      await client.delete({path:`/bookmarks/test10`})
+      return res.data;
+    })
+    expect(response).to.equal('aaa');
+  });
+
+  it("Recursive PUT/GET", async () => {
+    const randomStr = generateRandomStr();
+    var tree = {
+      bookmarks: {
+        _type: "application/json",
+        _rev: 0,
+      },
+    };
+    tree.bookmarks[randomStr] = {
+      _type: "application/json",
+      _rev: 0,
+      level1: {
+        "*": {
+          _type: "application/json",
+          _rev: 0,
+          level2: {
+            "*": {
+              _type: "application/json",
+              _rev: 0,
+              level3: {
+                "*": {
+                  _type: "application/json",
+                  _rev: 0,
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const client = await oada.connect({
+      domain: config.domain,
+      token: config.token,
+      connection: 'http',
+    });
+    // Tree PUT
+    await client.put({
+      path: `/bookmarks/${randomStr}/level1/abc/level2/def/level3/ghi/`,
+      data: { thingy: "abc" },
+      tree,
+    });
+    // Recursive GET
+    const response = await client.get({
+      path: `/bookmarks/${randomStr}`,
+      tree,
+    });
+    const responseData = response.data;
+    // check
+    expect(responseData).to.have.nested.property(`_type`);
+    expect(responseData).to.have.nested.property(`level1.abc._type`);
+    expect(responseData).to.have.nested.property(`level1.abc.level2.def._type`);
+    expect(responseData).to.have.nested.property(
+      `level1.abc.level2.def.level3.ghi._type`
+    );
+    // Cleanup
+    await client.delete({
+      path: `/bookmarks/${randomStr}`,
+    });
+    client.disconnect();
+  });
+});

--- a/test/put.test.ts
+++ b/test/put.test.ts
@@ -1,14 +1,15 @@
-import chai from "chai";
-const chaiAsPromised = require("chai-as-promised");
-chai.use(chaiAsPromised);
-const expect = chai.expect;
+import { expect, use } from "chai";
 import "mocha";
-import ksuid from "ksuid";
 import * as oada from "../lib/index";
 import * as config from "./config";
 import * as utils from "./utils";
+const ksuid = require("ksuid");
+use(require('chai-as-promised'));
 
-describe("PUT test", function () {
+['ws', 'http'].forEach(connection => {
+if (connection !== 'ws' && connection !== 'http') return;
+
+describe(`${connection}: PUT test`, function () {
   // Client instance
   let client: oada.OADAClient;
 
@@ -25,6 +26,7 @@ describe("PUT test", function () {
     client = await oada.connect({
       domain: config.domain,
       token: config.token,
+      connection
     });
   });
 
@@ -219,4 +221,6 @@ describe("PUT test", function () {
     expect(response.data).to.not.have.nested.property("test._id");
     expect(response.data).to.not.have.nested.property("test._rev");
   });
+});
+
 });


### PR DESCRIPTION
Allows client to specify http as the basis for oada/client requests, also can override the default internal connection which should allow things like Google Apps Script to be able to use client as well.