### PR TITLE
Enable external client

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -22,6 +22,11 @@ export {
   PUTRequest,
   HEADRequest,
   WatchRequest,
+  // These are for developing an external connection (like google apps script):
+  ConnectionRequest,
+  ConnectionResponse,
+  ConnectionChange,
+  Connection
 } from "./client";
 
 export type Json =

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oada/client",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A lightweight client tool to interact with an OADA-compliant server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
When writing the google apps script client as an external thing, I need these type exports from client.ts bumped up to index.